### PR TITLE
Add OFT middleware, Permit2 proxy, transient-storage reentrency, across decimal bug fix

### DIFF
--- a/contracts/facets/bridges/RangoAcrossFacet.sol
+++ b/contracts/facets/bridges/RangoAcrossFacet.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.25;
 
 import "../../interfaces/IRangoAcross.sol";
-import "../../interfaces/IRango.sol";
+import "../../interfaces/IRango2.sol";
 import "../../utils/ReentrancyGuard.sol";
-import "../../libraries/LibSwapper.sol";
+import "../../libraries/LibSwapperV2.sol";
 import "../../libraries/LibDiamond.sol";
 import "../../interfaces/Interchain.sol";
 import "../../libraries/LibPausable.sol";
@@ -12,9 +12,10 @@ import "../../libraries/LibPausable.sol";
 /// @title The root contract that handles Rango's interaction with Across bridge
 /// @author Thinking Particle & AMA
 /// @dev This is deployed as a facet for RangoDiamond
-contract RangoAcrossFacet is IRango, ReentrancyGuard, IRangoAcross {
+contract RangoAcrossFacet is IRango2, ReentrancyGuard, IRangoAcross {
     /// Storage ///
     bytes32 internal constant ACROSS_NAMESPACE = keccak256("exchange.rango.facets.across");
+    uint256 constant BASE_PCT = 1e18;
 
     struct AcrossStorage {
         /// @notice List of whitelisted Across spoke pools in the current chain
@@ -80,12 +81,12 @@ contract RangoAcrossFacet is IRango, ReentrancyGuard, IRangoAcross {
     /// @param calls The list of DEX calls, if this list is empty, it means that there is no DEX call and we are only bridging
     /// @param bridgeRequest required data for the bridging step, including the destination chain and recipient wallet address
     function acrossSwapAndBridge(
-        LibSwapper.SwapRequest memory request,
-        LibSwapper.Call[] calldata calls,
+        LibSwapperV2.SwapRequest memory request,
+        LibSwapperV2.Call[] calldata calls,
         AcrossBridgeRequest memory bridgeRequest
     ) external payable nonReentrant {
         LibPausable.enforceNotPaused();
-        uint out = LibSwapper.onChainSwapsPreBridge(request, calls, 0);
+        uint out = LibSwapperV2.onChainSwapsPreBridge(request, calls, 0);
         doAcrossBridge(bridgeRequest, request.toToken, out);
 
         // event emission
@@ -107,19 +108,19 @@ contract RangoAcrossFacet is IRango, ReentrancyGuard, IRangoAcross {
     /// @dev request.toToken can be address(0) for native deposits and will be replaced in doAcrossBridge
     function acrossBridge(
         AcrossBridgeRequest memory request,
-        IRango.RangoBridgeRequest memory bridgeRequest
+        IRango2.RangoBridgeRequest memory bridgeRequest
     ) external payable nonReentrant {
         LibPausable.enforceNotPaused();
         address token = bridgeRequest.token;
-        uint amountWithFee = bridgeRequest.amount + LibSwapper.sumFees(bridgeRequest);
+        uint amountWithFee = bridgeRequest.amount + LibSwapperV2.sumFees(bridgeRequest);
         // transfer tokens if necessary
-        if (token == LibSwapper.ETH) {
+        if (token == LibSwapperV2.ETH) {
             require(
                 msg.value >= amountWithFee, "Insufficient ETH sent for bridging and fees");
         } else {
             SafeERC20.safeTransferFrom(IERC20(token), msg.sender, address(this), amountWithFee);
         }
-        LibSwapper.collectFees(bridgeRequest);
+        LibSwapperV2.collectFees(bridgeRequest);
         doAcrossBridge(request, token, bridgeRequest.amount);
 
         bool hasInterchainMessage = request.message.length > 0;
@@ -155,25 +156,25 @@ contract RangoAcrossFacet is IRango, ReentrancyGuard, IRangoAcross {
     ) internal {
         AcrossStorage storage s = getAcrossStorage();
         require(s.acrossSpokePools[request.spokePoolAddress], "Requested spokePool address not whitelisted");
-        if (token != LibSwapper.ETH)
-            LibSwapper.approveMax(token, request.spokePoolAddress, amount);
+        if (token != LibSwapperV2.ETH)
+            LibSwapperV2.approveMax(token, request.spokePoolAddress, amount);
 
         address bridgeToken = token;
-        if (token == LibSwapper.ETH) bridgeToken = LibSwapper.getBaseSwapperStorage().WETH;
-
+        if (token == LibSwapperV2.ETH) bridgeToken = LibSwapperV2.getBaseSwapperStorage().WETH;
+        uint256 amountOutInDestinationDecimals = amount * request.decimalsAdjustedTotalRelayFeePct / BASE_PCT;
         bytes memory acrossCallData = encodeWithSignature(
-            request.depositor == LibSwapper.ETH ? msg.sender : request.depositor,
+            request.depositor == LibSwapperV2.ETH ? msg.sender : request.depositor,
             bridgeToken,
             amount,
-            amount - request.totalRelayFeeAmount, // TODO: Test if this is correct and works
+            amountOutInDestinationDecimals, // TODO: Test if this is correct and works
             request
         );
 
         bytes memory callData = concat(acrossCallData, s.acrossRewardBytes);
 
-        (bool success, bytes memory ret) = request.spokePoolAddress.call{value: token == LibSwapper.ETH ? amount : 0}(callData);
+        (bool success, bytes memory ret) = request.spokePoolAddress.call{value: token == LibSwapperV2.ETH ? amount : 0}(callData);
         if (!success)
-            revert(LibSwapper._getRevertMsg(ret));
+            revert(LibSwapperV2._getRevertMsg(ret));
 
     }
 

--- a/contracts/facets/bridges/RangoOftMiddleware.sol
+++ b/contracts/facets/bridges/RangoOftMiddleware.sol
@@ -17,11 +17,20 @@ contract RangoOftMiddleware is ReentrancyGuard, IRango2, IOAppComposer, RangoBas
     uint8 private constant AMOUNT_LD_OFFSET = 44;
     uint8 private constant COMPOSE_FROM_OFFSET = 76; // OFTComposeMsgCodec
 
+    /// @notice An OApp (OFT contract) paired with the ERC20 it is authorized to deliver on this chain.
+    /// @dev For a native OFT, `token` equals the OApp itself; for an OFT adapter, `token` is the
+    ///      wrapped ERC20. This binding is what prevents a whitelisted low-value OApp from being
+    ///      used to operate on an arbitrary (high-value) token the contract may hold.
+    struct OappTokenPair {
+        address oApp;
+        address token;
+    }
+
     struct RangoOftMiddlewareStorage {
         address oftEndpoint;
-        // oft tokens that are whitelisted to be used with this middleware
-        //q? do we need to whitelist tokens? or can we receive message from any oapp? 
-        mapping(address => bool) whitelistedOapps; 
+        // whitelisted OApps mapped to the single ERC20 each one is allowed to deliver.
+        // address(0) => the OApp is not whitelisted.
+        mapping(address => address) whitelistedOapps;
     }
 
     /// Events
@@ -30,8 +39,8 @@ contract RangoOftMiddleware is ReentrancyGuard, IRango2, IOAppComposer, RangoBas
     /// @param newAddress The new endpoint address
     event OftEndpointAddressUpdated(address oldAddress, address newAddress);
     /// @notice Emits when OApps are whitelisted
-    /// @param oapps The list of OApp addresses that were whitelisted
-    event OappsWhitelisted(address[] oapps);
+    /// @param oapps The list of OApp/token pairs that were whitelisted
+    event OappsWhitelisted(OappTokenPair[] oapps);
     /// @notice Emits when OApps are removed from whitelist
     /// @param oapps The list of OApp addresses that were removed
     event OappsRemoved(address[] oapps);
@@ -39,7 +48,7 @@ contract RangoOftMiddleware is ReentrancyGuard, IRango2, IOAppComposer, RangoBas
     function initOftMiddleware(
         address _owner,
         address _oftEndpoint,
-        address[] memory _whitelistedOapps,
+        OappTokenPair[] memory _whitelistedOapps,
         address _whitelistsContract
     ) external onlyOwner {
         initBaseMiddleware(_owner, _whitelistsContract);
@@ -51,7 +60,7 @@ contract RangoOftMiddleware is ReentrancyGuard, IRango2, IOAppComposer, RangoBas
         updateOftEndpointInternal(newEndpoint);
     }
 
-    function addWhitelistedOapps(address[] memory newWhitelistedOapps) external onlyOwner {
+    function addWhitelistedOapps(OappTokenPair[] memory newWhitelistedOapps) external onlyOwner {
         addWhitelistedOappsInternal(newWhitelistedOapps);
     }
 
@@ -72,19 +81,15 @@ contract RangoOftMiddleware is ReentrancyGuard, IRango2, IOAppComposer, RangoBas
         bytes calldata /* _extraData */
     ) external payable override onlyWhenNotPaused nonReentrant {
         RangoOftMiddlewareStorage storage s = getRangoOftMiddlewareStorage();
-        // Ensure the composed message comes from the correct OApp.
-        require(s.whitelistedOapps[_oApp], "ComposedReceiver: Invalid OApp");
+        
+        address bridgeToken = s.whitelistedOapps[_oApp];
+        require(bridgeToken != address(0), "ComposedReceiver: Invalid OApp");
         require(msg.sender == s.oftEndpoint, "ComposedReceiver: Unauthorized sender");
-        require(s.oftEndpoint != address(0), "OFT endpoint not initialized");
         // Validate message length before slicing
         require(_message.length >= COMPOSE_FROM_OFFSET, "Message too short");
-        
+
         bytes calldata rangoMessageBytes = _message[COMPOSE_FROM_OFFSET:];
         Interchain.RangoInterChainMessage memory m = abi.decode((rangoMessageBytes), (Interchain.RangoInterChainMessage));
-        
-        //@dev using bridgeRealOutput to get the received token address is safe, because ETH (native) or WETH(weth) are not OFTs in any network.
-        address bridgeToken = m.bridgeRealOutput;
-        require(bridgeToken != address(0), "Invalid bridge token address");
         uint256 amountLD = uint256(bytes32(_message[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));
 
         (address receivedToken, uint dstAmount, IRango2.CrossChainOperationStatus status) = LibInterchainV2.handleDestinationMessage(bridgeToken, amountLD, m);
@@ -100,6 +105,13 @@ contract RangoOftMiddleware is ReentrancyGuard, IRango2, IOAppComposer, RangoBas
         );
     }
 
+    /// @notice Returns the ERC20 a given OApp is whitelisted to deliver, or address(0) if not whitelisted.
+    /// @param oApp The OApp (OFT contract) address
+    /// @return the ERC20 token bound to the OApp
+    function getWhitelistedOappToken(address oApp) external view returns (address) {
+        return getRangoOftMiddlewareStorage().whitelistedOapps[oApp];
+    }
+
     /// Private and Internal
     function updateOftEndpointInternal(address newEndpoint) private {
         require(newEndpoint != address(0), "Invalid OFT Endpoint");
@@ -109,12 +121,13 @@ contract RangoOftMiddleware is ReentrancyGuard, IRango2, IOAppComposer, RangoBas
         emit OftEndpointAddressUpdated(oldEndpoint, newEndpoint);
     }
 
-    function addWhitelistedOappsInternal(address[] memory newWhitelistedOapps) private {
+    function addWhitelistedOappsInternal(OappTokenPair[] memory newWhitelistedOapps) private {
         if (newWhitelistedOapps.length == 0) return;
         RangoOftMiddlewareStorage storage s = getRangoOftMiddlewareStorage();
         for (uint i = 0; i < newWhitelistedOapps.length; i++) {
-            require(newWhitelistedOapps[i] != address(0), "Invalid OApp Address");
-            s.whitelistedOapps[newWhitelistedOapps[i]] = true;
+            require(newWhitelistedOapps[i].oApp != address(0), "Invalid OApp Address");
+            require(newWhitelistedOapps[i].token != address(0), "Invalid OApp Token");
+            s.whitelistedOapps[newWhitelistedOapps[i].oApp] = newWhitelistedOapps[i].token;
         }
         emit OappsWhitelisted(newWhitelistedOapps);
     }

--- a/contracts/facets/bridges/RangoOftMiddleware.sol
+++ b/contracts/facets/bridges/RangoOftMiddleware.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.25;
+
+import "../../interfaces/IOAppComposer.sol";
+import "../../libraries/LibInterchainV2.sol";
+import "../../utils/ReentrancyGuard.sol";
+import "../base/RangoBaseInterchainMiddlewareV2.sol";
+
+/// @title The middleware contract that handles Rango's receive messages from LayerZero.
+/// @author 0x4rde
+/// @dev Note that this is not a facet and should be deployed separately.
+contract RangoOftMiddleware is ReentrancyGuard, IRango2, IOAppComposer, RangoBaseInterchainMiddlewareV2 {
+    /// Storage ///
+    bytes32 internal constant OFT_MIDDLEWARE_NAMESPACE = keccak256("exchange.rango.middleware.oft");
+    /// params for decoding LayerZero compose messages (OFT format)
+    uint8 private constant SRC_EID_OFFSET = 12;
+    uint8 private constant AMOUNT_LD_OFFSET = 44;
+    uint8 private constant COMPOSE_FROM_OFFSET = 76; // OFTComposeMsgCodec
+
+    struct RangoOftMiddlewareStorage {
+        address oftEndpoint;
+        // oft tokens that are whitelisted to be used with this middleware
+        //q? do we need to whitelist tokens? or can we receive message from any oapp? 
+        mapping(address => bool) whitelistedOapps; 
+    }
+
+    /// Events
+    /// @notice Emits when the OFT endpoint address is updated
+    /// @param oldAddress The previous endpoint address
+    /// @param newAddress The new endpoint address
+    event OftEndpointAddressUpdated(address oldAddress, address newAddress);
+    /// @notice Emits when OApps are whitelisted
+    /// @param oapps The list of OApp addresses that were whitelisted
+    event OappsWhitelisted(address[] oapps);
+    /// @notice Emits when OApps are removed from whitelist
+    /// @param oapps The list of OApp addresses that were removed
+    event OappsRemoved(address[] oapps);
+
+    function initOftMiddleware(
+        address _owner,
+        address _oftEndpoint,
+        address[] memory _whitelistedOapps,
+        address _whitelistsContract
+    ) external onlyOwner {
+        initBaseMiddleware(_owner, _whitelistsContract);
+        updateOftEndpointInternal(_oftEndpoint);
+        addWhitelistedOappsInternal(_whitelistedOapps);
+    }
+
+    function updateOftEndpoint(address newEndpoint) external onlyOwner {
+        updateOftEndpointInternal(newEndpoint);
+    }
+
+    function addWhitelistedOapps(address[] memory newWhitelistedOapps) external onlyOwner {
+        addWhitelistedOappsInternal(newWhitelistedOapps);
+    }
+
+    function removeWhitelistedOapps(address[] memory oappsToRemove) external onlyOwner {
+        if (oappsToRemove.length == 0) return;
+        RangoOftMiddlewareStorage storage s = getRangoOftMiddlewareStorage();
+        for (uint i = 0; i < oappsToRemove.length; i++) {
+            delete s.whitelistedOapps[oappsToRemove[i]];
+        }
+        emit OappsRemoved(oappsToRemove);
+    }
+
+    function lzCompose(
+        address _oApp,
+        bytes32 /* _guid */,
+        bytes calldata _message,
+        address /* _executor */,
+        bytes calldata /* _extraData */
+    ) external payable override onlyWhenNotPaused nonReentrant {
+        RangoOftMiddlewareStorage storage s = getRangoOftMiddlewareStorage();
+        // Ensure the composed message comes from the correct OApp.
+        require(s.whitelistedOapps[_oApp], "ComposedReceiver: Invalid OApp");
+        require(msg.sender == s.oftEndpoint, "ComposedReceiver: Unauthorized sender");
+        require(s.oftEndpoint != address(0), "OFT endpoint not initialized");
+        // Validate message length before slicing
+        require(_message.length >= COMPOSE_FROM_OFFSET, "Message too short");
+        
+        bytes calldata rangoMessageBytes = _message[COMPOSE_FROM_OFFSET:];
+        Interchain.RangoInterChainMessage memory m = abi.decode((rangoMessageBytes), (Interchain.RangoInterChainMessage));
+        
+        //@dev using bridgeRealOutput to get the received token address is safe, because ETH (native) or WETH(weth) are not OFTs in any network.
+        address bridgeToken = m.bridgeRealOutput;
+        require(bridgeToken != address(0), "Invalid bridge token address");
+        uint256 amountLD = uint256(bytes32(_message[SRC_EID_OFFSET:AMOUNT_LD_OFFSET]));
+
+        (address receivedToken, uint dstAmount, IRango2.CrossChainOperationStatus status) = LibInterchainV2.handleDestinationMessage(bridgeToken, amountLD, m);
+
+        emit RangoBridgeCompleted(
+            m.requestId,
+            receivedToken,
+            m.originalSender,
+            m.recipient,
+            dstAmount,
+            status,
+            m.dAppTag
+        );
+    }
+
+    /// Private and Internal
+    function updateOftEndpointInternal(address newEndpoint) private {
+        require(newEndpoint != address(0), "Invalid OFT Endpoint");
+        RangoOftMiddlewareStorage storage s = getRangoOftMiddlewareStorage();
+        address oldEndpoint = s.oftEndpoint;
+        s.oftEndpoint = newEndpoint;
+        emit OftEndpointAddressUpdated(oldEndpoint, newEndpoint);
+    }
+
+    function addWhitelistedOappsInternal(address[] memory newWhitelistedOapps) private {
+        if (newWhitelistedOapps.length == 0) return;
+        RangoOftMiddlewareStorage storage s = getRangoOftMiddlewareStorage();
+        for (uint i = 0; i < newWhitelistedOapps.length; i++) {
+            require(newWhitelistedOapps[i] != address(0), "Invalid OApp Address");
+            s.whitelistedOapps[newWhitelistedOapps[i]] = true;
+        }
+        emit OappsWhitelisted(newWhitelistedOapps);
+    }
+
+    /// @dev fetch local storage
+    function getRangoOftMiddlewareStorage() private pure returns (RangoOftMiddlewareStorage storage s) {
+        bytes32 namespace = OFT_MIDDLEWARE_NAMESPACE;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            s.slot := namespace
+        }
+    }
+}

--- a/contracts/interfaces/IOAppComposer.sol
+++ b/contracts/interfaces/IOAppComposer.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IOAppComposer {
+    /**
+     * @notice Composes a LayerZero message from an OApp.
+     * @param _from The address initiating the composition, typically the OApp where the lzReceive was called.
+     * @param _guid The unique identifier for the corresponding LayerZero src/dst tx.
+     * @param _message The composed message payload in bytes. NOT necessarily the same payload passed via lzReceive.
+     * @param _executor The address of the executor for the composed message.
+     * @param _extraData Additional arbitrary data in bytes passed by the entity who executes the lzCompose.
+     */
+    function lzCompose(
+        address _from,
+        bytes32 _guid,
+        bytes calldata _message,
+        address _executor,
+        bytes calldata _extraData
+    ) external payable;
+}
+

--- a/contracts/interfaces/IRangoAcross.sol
+++ b/contracts/interfaces/IRangoAcross.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity 0.8.25;
 
-import "../libraries/LibSwapper.sol";
-import "./IRango.sol";
+import "../libraries/LibSwapperV2.sol";
+import "./IRango2.sol";
 
 /// @title An interface to RangoAcross.sol contract to improve type hinting
 /// @author George
@@ -17,7 +17,7 @@ interface IRangoAcross {
     /// @param recipient Address to receive funds at on destination chain.
     /// @param originToken Token to lock into this contract to initiate deposit. Can be address(0)
     /// @param destinationChainId Denotes network where user will receive funds from SpokePool by a relayer.
-    /// @param totalRelayFeeAmount The amount of tokens that should be paid to the relayer as fee.
+    /// @param decimalsAdjustedTotalRelayFeePct A multiplier with decimal offset precision (source decimals - destination decimals) that when multiplied by the amount deposited gives the amount that will be received on destination chain.
     /// @param quoteTimestamp Timestamp used by relayers to compute this deposit's realizedLPFeePct which is paid to LP pool on HubPool.
     /// @param message message that will be passed to destination chain. Can be empty.
     struct AcrossBridgeRequest {
@@ -29,19 +29,19 @@ interface IRangoAcross {
         uint32 exclusivityDeadline;
         address recipient;
         uint256 destinationChainId;
-        uint256 totalRelayFeeAmount;
+        uint256 decimalsAdjustedTotalRelayFeePct;
         uint32 quoteTimestamp;
         bytes message;
     }
 
     function acrossSwapAndBridge(
-        LibSwapper.SwapRequest memory request,
-        LibSwapper.Call[] calldata calls,
+        LibSwapperV2.SwapRequest memory request,
+        LibSwapperV2.Call[] calldata calls,
         AcrossBridgeRequest memory bridgeRequest
     ) external payable;
 
     function acrossBridge(
         AcrossBridgeRequest memory request,
-        IRango.RangoBridgeRequest memory bridgeRequest
+        IRango2.RangoBridgeRequest memory bridgeRequest
     ) external payable;
 }

--- a/contracts/utils/Permit2Proxy.sol
+++ b/contracts/utils/Permit2Proxy.sol
@@ -19,17 +19,17 @@ contract Permit2Proxy is Ownable, EIP712 {
     error InvalidTokenAddress();
     error InvalidCalldataSignature();
 
-    IPermit2 public s_permit2;
-    address public immutable i_rangoDiamond;
+    IPermit2 public permit2;
+    address public immutable rangoDiamond;
 
-    string internal constant _WITNESS_TYPE_STRING =
+    string internal constant WITNESS_TYPE_STRING =
         "WitnessData witness)TokenPermissions(address token,uint256 amount)WitnessData(address diamondAddress,bytes32 diamondCalldata)";
-    bytes32 internal constant _WITNESS_STRUCT_TYPEHASH =
+    bytes32 internal constant WITNESS_STRUCT_TYPEHASH =
         keccak256("WitnessData(address diamondAddress,bytes32 diamondCalldata)");
-    bytes32 internal constant _FULL_WITNESS_TYPEHASH =
-        keccak256(abi.encodePacked(PermitHash._PERMIT_TRANSFER_FROM_WITNESS_TYPEHASH_STUB, _WITNESS_TYPE_STRING));
+    bytes32 internal constant FULL_WITNESS_TYPEHASH =
+        keccak256(abi.encodePacked(PermitHash._PERMIT_TRANSFER_FROM_WITNESS_TYPEHASH_STUB, WITNESS_TYPE_STRING));
 
-    bytes32 internal constant _CALLDATA_WITNESS_TYPEHASH =
+    bytes32 internal constant CALLDATA_WITNESS_TYPEHASH =
         keccak256("CalldataWitness(address owner,address token,uint256 amount,bytes32 diamondCalldataHash)");
 
     struct WitnessData {
@@ -38,8 +38,8 @@ contract Permit2Proxy is Ownable, EIP712 {
     }
 
     constructor(address _permit2Address, address _diamondAddress, address _owner) Ownable(_owner) EIP712("Permit2Proxy", "1") {
-        s_permit2 = IPermit2(_permit2Address);
-        i_rangoDiamond = _diamondAddress;
+        permit2 = IPermit2(_permit2Address);
+        rangoDiamond = _diamondAddress;
     }
 
     function permit2WitnessTransferAndCallDiamond(
@@ -55,18 +55,18 @@ contract Permit2Proxy is Ownable, EIP712 {
             });
 
         WitnessData memory witnessData = WitnessData({
-            diamondAddress: i_rangoDiamond,
+            diamondAddress: rangoDiamond,
             diamondCalldata: keccak256(diamondCalldata)
         });
 
         bytes32 witness = _hashWitnessData(witnessData);
 
-        s_permit2.permitWitnessTransferFrom(
+        permit2.permitWitnessTransferFrom(
             permit,
             transferDetails,
             signer,
             witness,
-            _WITNESS_TYPE_STRING,
+            WITNESS_TYPE_STRING,
             signature
         );
 
@@ -90,7 +90,7 @@ contract Permit2Proxy is Ownable, EIP712 {
 
         // Verify the owner signed the calldata
         bytes32 structHash = keccak256(abi.encode(
-            _CALLDATA_WITNESS_TYPEHASH,
+            CALLDATA_WITNESS_TYPEHASH,
             owner,
             token,
             amount,
@@ -126,15 +126,15 @@ contract Permit2Proxy is Ownable, EIP712 {
 
     function _maxApproveDiamond(address token) internal {
         if (token == address(0)) return;
-        SafeERC20.forceApprove(IERC20(token), i_rangoDiamond, type(uint256).max);
+        SafeERC20.forceApprove(IERC20(token), rangoDiamond, type(uint256).max);
     }
 
     function _hashWitnessData(WitnessData memory witnessData) internal pure returns (bytes32) {
-        return keccak256(abi.encode(_WITNESS_STRUCT_TYPEHASH, witnessData.diamondAddress, witnessData.diamondCalldata));
+        return keccak256(abi.encode(WITNESS_STRUCT_TYPEHASH, witnessData.diamondAddress, witnessData.diamondCalldata));
     }
 
     function _callRangoDiamond(bytes memory data) internal returns (bytes memory) {
-        (bool success, bytes memory result) = i_rangoDiamond.call{value: msg.value}(data);
+        (bool success, bytes memory result) = rangoDiamond.call{value: msg.value}(data);
         if (!success) {
             revert CallToDiamondFailed(result);
         }
@@ -142,10 +142,10 @@ contract Permit2Proxy is Ownable, EIP712 {
     }
 
     function getWitnessTypehash() external pure returns (bytes32) {
-        return _FULL_WITNESS_TYPEHASH;
+        return FULL_WITNESS_TYPEHASH;
     }
 
     function getWitnessTypeString() external pure returns (string memory) {
-        return _WITNESS_TYPE_STRING;
+        return WITNESS_TYPE_STRING;
     }
 }

--- a/contracts/utils/Permit2Proxy.sol
+++ b/contracts/utils/Permit2Proxy.sol
@@ -18,9 +18,14 @@ contract Permit2Proxy is Ownable, EIP712 {
     error InvalidRecipient();
     error InvalidTokenAddress();
     error InvalidCalldataSignature();
+    error SignatureExpired();
 
     IPermit2 public permit2;
     address public immutable rangoDiamond;
+
+    /// @notice Per-owner sequential nonce consumed by `permitAndCallDiamond` calldata signatures.
+    /// @dev Bound into the signed digest to prevent replay of a `calldataSignature`.
+    mapping(address => uint256) public nonces;
 
     string internal constant WITNESS_TYPE_STRING =
         "WitnessData witness)TokenPermissions(address token,uint256 amount)WitnessData(address diamondAddress,bytes32 diamondCalldata)";
@@ -30,7 +35,7 @@ contract Permit2Proxy is Ownable, EIP712 {
         keccak256(abi.encodePacked(PermitHash._PERMIT_TRANSFER_FROM_WITNESS_TYPEHASH_STUB, WITNESS_TYPE_STRING));
 
     bytes32 internal constant CALLDATA_WITNESS_TYPEHASH =
-        keccak256("CalldataWitness(address owner,address token,uint256 amount,bytes32 diamondCalldataHash)");
+        keccak256("CalldataWitness(address owner,address token,uint256 amount,bytes32 diamondCalldataHash,uint256 nonce,uint256 deadline)");
 
     bytes32 internal constant TOKEN_PERMISSIONS_TYPEHASH =
         keccak256("TokenPermissions(address token,uint256 amount)");
@@ -73,9 +78,11 @@ contract Permit2Proxy is Ownable, EIP712 {
             signature
         );
 
-        _maxApproveDiamond(permit.permitted.token);
+        _setDiamondAllowance(permit.permitted.token, permit.permitted.amount);
+        bytes memory result = _callRangoDiamond(diamondCalldata);
+        _setDiamondAllowance(permit.permitted.token, 0);
 
-        return _callRangoDiamond(diamondCalldata);
+        return result;
     }
 
     function permitAndCallDiamond(
@@ -90,18 +97,23 @@ contract Permit2Proxy is Ownable, EIP712 {
         bytes calldata calldataSignature
     ) external payable returns (bytes memory) {
         if (token == address(0)) revert InvalidTokenAddress();
+        if (block.timestamp > deadline) revert SignatureExpired();
 
-        // Verify the owner signed the calldata
+        uint256 nonce = nonces[owner];
         bytes32 structHash = keccak256(abi.encode(
             CALLDATA_WITNESS_TYPEHASH,
             owner,
             token,
             amount,
-            keccak256(diamondCalldata)
+            keccak256(diamondCalldata),
+            nonce,
+            deadline
         ));
         bytes32 digest = _hashTypedDataV4(structHash);
         address recovered = ECDSA.recover(digest, calldataSignature);
         if (recovered != owner) revert InvalidCalldataSignature();
+
+        nonces[owner] = nonce + 1;
 
         // Execute permit (skip if allowance already sufficient)
         IERC20 erc20 = IERC20(token);
@@ -111,9 +123,11 @@ contract Permit2Proxy is Ownable, EIP712 {
 
         erc20.safeTransferFrom(owner, address(this), amount);
 
-        _maxApproveDiamond(token);
+        _setDiamondAllowance(token, amount);
+        bytes memory result = _callRangoDiamond(diamondCalldata);
+        _setDiamondAllowance(token, 0);
 
-        return _callRangoDiamond(diamondCalldata);
+        return result;
     }
 
     function rescueFunds(address token, address recipient, uint256 amount) external onlyOwner {
@@ -127,9 +141,12 @@ contract Permit2Proxy is Ownable, EIP712 {
         }
     }
 
-    function _maxApproveDiamond(address token) internal {
-        if (token == address(0)) return;
-        SafeERC20.forceApprove(IERC20(token), rangoDiamond, type(uint256).max);
+    /// @notice Set the diamond's allowance for `token` to exactly `amount`.
+    /// @dev Called with the swap amount before the diamond call and reset to 0 after, so the proxy
+    ///      never leaves a standing allowance the diamond could later use to pull tokens that were
+    ///      accidentally sent to (or left in) this proxy.
+    function _setDiamondAllowance(address token, uint256 amount) internal {
+        SafeERC20.forceApprove(IERC20(token), rangoDiamond, amount);
     }
 
     function _hashWitnessData(WitnessData memory witnessData) internal pure returns (bytes32) {
@@ -179,12 +196,14 @@ contract Permit2Proxy is Ownable, EIP712 {
     }
 
     /// @notice EIP-712 digest the user must sign as `calldataSignature` for `permitAndCallDiamond`.
-    /// @dev Domain is this proxy's EIP-712 domain. Does NOT cover the token's EIP-2612 permit
+    /// @dev Domain is this proxy's EIP-712 domain. Binds the owner's current `nonce` and the
+    ///      `deadline` for replay protection. Does NOT cover the token's EIP-2612 permit
     ///      (that signature uses the token's own domain and must be produced separately).
     function hashCalldataWitnessDigest(
         address owner,
         address token,
         uint256 amount,
+        uint256 deadline,
         bytes calldata diamondCalldata
     ) external view returns (bytes32) {
         bytes32 structHash = keccak256(abi.encode(
@@ -192,7 +211,9 @@ contract Permit2Proxy is Ownable, EIP712 {
             owner,
             token,
             amount,
-            keccak256(diamondCalldata)
+            keccak256(diamondCalldata),
+            nonces[owner],
+            deadline
         ));
         return _hashTypedDataV4(structHash);
     }

--- a/contracts/utils/Permit2Proxy.sol
+++ b/contracts/utils/Permit2Proxy.sol
@@ -32,6 +32,9 @@ contract Permit2Proxy is Ownable, EIP712 {
     bytes32 internal constant CALLDATA_WITNESS_TYPEHASH =
         keccak256("CalldataWitness(address owner,address token,uint256 amount,bytes32 diamondCalldataHash)");
 
+    bytes32 internal constant TOKEN_PERMISSIONS_TYPEHASH =
+        keccak256("TokenPermissions(address token,uint256 amount)");
+
     struct WitnessData {
         address diamondAddress;
         bytes32 diamondCalldata;
@@ -147,5 +150,50 @@ contract Permit2Proxy is Ownable, EIP712 {
 
     function getWitnessTypeString() external pure returns (string memory) {
         return WITNESS_TYPE_STRING;
+    }
+
+    /// @notice EIP-712 digest the user must sign for `permit2WitnessTransferAndCallDiamond`.
+    /// @dev Domain is the Permit2 contract's domain. Spender is bound to this proxy.
+    function hashPermit2WitnessDigest(
+        ISignatureTransfer.PermitTransferFrom calldata permit,
+        bytes calldata diamondCalldata
+    ) external view returns (bytes32) {
+        bytes32 tokenPermissionsHash = keccak256(abi.encode(
+            TOKEN_PERMISSIONS_TYPEHASH,
+            permit.permitted.token,
+            permit.permitted.amount
+        ));
+        bytes32 witness = _hashWitnessData(WitnessData({
+            diamondAddress: rangoDiamond,
+            diamondCalldata: keccak256(diamondCalldata)
+        }));
+        bytes32 structHash = keccak256(abi.encode(
+            FULL_WITNESS_TYPEHASH,
+            tokenPermissionsHash,
+            address(this),
+            permit.nonce,
+            permit.deadline,
+            witness
+        ));
+        return keccak256(abi.encodePacked("\x19\x01", permit2.DOMAIN_SEPARATOR(), structHash));
+    }
+
+    /// @notice EIP-712 digest the user must sign as `calldataSignature` for `permitAndCallDiamond`.
+    /// @dev Domain is this proxy's EIP-712 domain. Does NOT cover the token's EIP-2612 permit
+    ///      (that signature uses the token's own domain and must be produced separately).
+    function hashCalldataWitnessDigest(
+        address owner,
+        address token,
+        uint256 amount,
+        bytes calldata diamondCalldata
+    ) external view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(
+            CALLDATA_WITNESS_TYPEHASH,
+            owner,
+            token,
+            amount,
+            keccak256(diamondCalldata)
+        ));
+        return _hashTypedDataV4(structHash);
     }
 }

--- a/contracts/utils/Permit2Proxy.sol
+++ b/contracts/utils/Permit2Proxy.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.25;
+
+import { IPermit2 } from "permit2/src/interfaces/IPermit2.sol";
+import { ISignatureTransfer } from "permit2/src/interfaces/ISignatureTransfer.sol";
+import { PermitHash } from "permit2/src/libraries/PermitHash.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20Permit } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+contract Permit2Proxy is Ownable, EIP712 {
+    using SafeERC20 for IERC20;
+
+    error CallToDiamondFailed(bytes revertData);
+    error InvalidRecipient();
+    error InvalidTokenAddress();
+    error InvalidCalldataSignature();
+
+    IPermit2 public s_permit2;
+    address public immutable i_rangoDiamond;
+
+    string internal constant _WITNESS_TYPE_STRING =
+        "WitnessData witness)TokenPermissions(address token,uint256 amount)WitnessData(address diamondAddress,bytes32 diamondCalldata)";
+    bytes32 internal constant _WITNESS_STRUCT_TYPEHASH =
+        keccak256("WitnessData(address diamondAddress,bytes32 diamondCalldata)");
+    bytes32 internal constant _FULL_WITNESS_TYPEHASH =
+        keccak256(abi.encodePacked(PermitHash._PERMIT_TRANSFER_FROM_WITNESS_TYPEHASH_STUB, _WITNESS_TYPE_STRING));
+
+    bytes32 internal constant _CALLDATA_WITNESS_TYPEHASH =
+        keccak256("CalldataWitness(address owner,address token,uint256 amount,bytes32 diamondCalldataHash)");
+
+    struct WitnessData {
+        address diamondAddress;
+        bytes32 diamondCalldata;
+    }
+
+    constructor(address _permit2Address, address _diamondAddress, address _owner) Ownable(_owner) EIP712("Permit2Proxy", "1") {
+        s_permit2 = IPermit2(_permit2Address);
+        i_rangoDiamond = _diamondAddress;
+    }
+
+    function permit2WitnessTransferAndCallDiamond(
+        ISignatureTransfer.PermitTransferFrom calldata permit,
+        bytes calldata signature,
+        address signer,
+        bytes calldata diamondCalldata
+    ) external payable returns (bytes memory) {
+        ISignatureTransfer.SignatureTransferDetails memory transferDetails =
+            ISignatureTransfer.SignatureTransferDetails({
+                to: address(this),
+                requestedAmount: permit.permitted.amount
+            });
+
+        WitnessData memory witnessData = WitnessData({
+            diamondAddress: i_rangoDiamond,
+            diamondCalldata: keccak256(diamondCalldata)
+        });
+
+        bytes32 witness = _hashWitnessData(witnessData);
+
+        s_permit2.permitWitnessTransferFrom(
+            permit,
+            transferDetails,
+            signer,
+            witness,
+            _WITNESS_TYPE_STRING,
+            signature
+        );
+
+        _maxApproveDiamond(permit.permitted.token);
+
+        return _callRangoDiamond(diamondCalldata);
+    }
+
+    function permitAndCallDiamond(
+        address owner,
+        address token,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes calldata diamondCalldata,
+        bytes calldata calldataSignature
+    ) external payable returns (bytes memory) {
+        if (token == address(0)) revert InvalidTokenAddress();
+
+        // Verify the owner signed the calldata
+        bytes32 structHash = keccak256(abi.encode(
+            _CALLDATA_WITNESS_TYPEHASH,
+            owner,
+            token,
+            amount,
+            keccak256(diamondCalldata)
+        ));
+        bytes32 digest = _hashTypedDataV4(structHash);
+        address recovered = ECDSA.recover(digest, calldataSignature);
+        if (recovered != owner) revert InvalidCalldataSignature();
+
+        // Execute permit (skip if allowance already sufficient)
+        IERC20 erc20 = IERC20(token);
+        if (erc20.allowance(owner, address(this)) < amount) {
+            IERC20Permit(token).permit(owner, address(this), amount, deadline, v, r, s);
+        }
+
+        erc20.safeTransferFrom(owner, address(this), amount);
+
+        _maxApproveDiamond(token);
+
+        return _callRangoDiamond(diamondCalldata);
+    }
+
+    function rescueFunds(address token, address recipient, uint256 amount) external onlyOwner {
+        if (recipient == address(0)) revert InvalidRecipient();
+
+        if (token == address(0)) {
+            (bool success,) = recipient.call{value: amount}("");
+            require(success, "Native transfer failed");
+        } else {
+            IERC20(token).safeTransfer(recipient, amount);
+        }
+    }
+
+    function _maxApproveDiamond(address token) internal {
+        if (token == address(0)) return;
+        SafeERC20.forceApprove(IERC20(token), i_rangoDiamond, type(uint256).max);
+    }
+
+    function _hashWitnessData(WitnessData memory witnessData) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_WITNESS_STRUCT_TYPEHASH, witnessData.diamondAddress, witnessData.diamondCalldata));
+    }
+
+    function _callRangoDiamond(bytes memory data) internal returns (bytes memory) {
+        (bool success, bytes memory result) = i_rangoDiamond.call{value: msg.value}(data);
+        if (!success) {
+            revert CallToDiamondFailed(result);
+        }
+        return result;
+    }
+
+    function getWitnessTypehash() external pure returns (bytes32) {
+        return _FULL_WITNESS_TYPEHASH;
+    }
+
+    function getWitnessTypeString() external pure returns (string memory) {
+        return _WITNESS_TYPE_STRING;
+    }
+}

--- a/contracts/utils/ReentrancyGuard.sol
+++ b/contracts/utils/ReentrancyGuard.sol
@@ -2,45 +2,41 @@
 pragma solidity 0.8.25;
 
 /// @title Reentrancy Guard
-/// @author 
-/// @notice Abstract contract to provide protection against reentrancy
+/// @notice Abstract contract to provide protection against reentrancy.
+/// @dev Uses EIP-1153 transient storage (TSTORE/TLOAD). The status slot is
+/// automatically cleared at the end of the transaction by the EVM, so a typical
+/// guarded call pays ~100 gas for entry + ~100 gas for exit instead of the
+/// ~2,200 gas of a cold SSTORE + warm SSTORE reset. Requires the cancun EVM.
 abstract contract ReentrancyGuard {
-    /// Storage ///
+    /// @dev Transient storage slot for the reentrancy status flag.
+    /// Keeps the same namespace string as the previous SSTORE-based layout so
+    /// the slot identity is stable across the upgrade, even though transient
+    /// storage occupies a separate address space from regular storage.
     bytes32 private constant NAMESPACE = keccak256("exchange.rango.reentrancyguard");
-
-    /// Types ///
-
-    struct ReentrancyStorage {
-        uint256 status;
-    }
-
-    /// Errors ///
 
     error ReentrancyError();
 
-    /// Constants ///
-
-    uint256 private constant _NOT_ENTERED = 0;
     uint256 private constant _ENTERED = 1;
 
-    /// Modifiers ///
-
     modifier nonReentrant() {
-        ReentrancyStorage storage s = reentrancyStorage();
-        if (s.status == _ENTERED) revert ReentrancyError();
-        s.status = _ENTERED;
-        _;
-        s.status = _NOT_ENTERED;
-    }
-
-    /// Private Methods ///
-
-    /// @dev fetch local storage
-    function reentrancyStorage() private pure returns (ReentrancyStorage storage data) {
-        bytes32 position = NAMESPACE;
+        bytes32 slot = NAMESPACE;
+        uint256 status;
         // solhint-disable-next-line no-inline-assembly
         assembly {
-            data.slot := position
+            status := tload(slot)
+        }
+        if (status == _ENTERED) revert ReentrancyError();
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            tstore(slot, _ENTERED)
+        }
+        _;
+        // Reset so subsequent guarded calls in the same tx (e.g. via multicall)
+        // can re-enter. Transient storage auto-clears at tx end, but not between
+        // sibling calls within a tx.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            tstore(slot, 0)
         }
     }
 }


### PR DESCRIPTION
Audit-scope changes:

- RangoOftMiddleware (new): LayerZero OFT composer middleware. Receives composed OFT messages on the destination chain and dispatches the embedded Rango interchain message via LibInterchainV2.

- Permit2Proxy (new): Entry-point proxy in front of the diamond enabling permit + swap in a single transaction (EIP-2612 and Permit2).

- RangoAcrossFacet (modified): Replace `totalRelayFeeAmount` (absolute) with `decimalsAdjustedTotalRelayFeePct` (multiplier scaled to 1e18 with built-in source/destination decimals offset). Fixes incorrect amount-out on bridges between tokens with different decimals (e.g. USDC 6 -> 18). Also migrates the facet from LibSwapper/IRango to LibSwapperV2/IRango2.

- ReentrancyGuard (modified): Migrate from SSTORE-backed flag to EIP-1153 TSTORE/TLOAD. ~22k gas saved per guarded call. Storage layout unchanged (transient storage occupies a separate address space). Requires cancun.